### PR TITLE
Link with libm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = $(CROSS_COMPILE)gcc
 OFLAGS = -O3 -fomit-frame-pointer
 CFLAGS = -Wall -Werror $(OFLAGS) -g
-LFLAGS = -lbsd -lbrahe -lpthread
+LFLAGS = -lbsd -lbrahe -lpthread -lm
 
 TARGET =	sertest
 


### PR DESCRIPTION
$ make
CC sertest.c
LD sertest
/usr/lib/gcc/x86_64-pc-linux-gnu/6.1.1/../../../../lib/libbrahe.so: undefined reference to `sincos'
/usr/lib/gcc/x86_64-pc-linux-gnu/6.1.1/../../../../lib/libbrahe.so: undefined reference to`sin'
/usr/lib/gcc/x86_64-pc-linux-gnu/6.1.1/../../../../lib/libbrahe.so: undefined reference to `log'
/usr/lib/gcc/x86_64-pc-linux-gnu/6.1.1/../../../../lib/libbrahe.so: undefined reference to`pow'
/usr/lib/gcc/x86_64-pc-linux-gnu/6.1.1/../../../../lib/libbrahe.so: undefined reference to `log10'
/usr/lib/gcc/x86_64-pc-linux-gnu/6.1.1/../../../../lib/libbrahe.so: undefined reference to`sqrt'
/usr/lib/gcc/x86_64-pc-linux-gnu/6.1.1/../../../../lib/libbrahe.so: undefined reference to `floor'
collect2: error: ld returned 1 exit status
